### PR TITLE
ci: drop dependabot target-branch, develop is abandoned

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    target-branch: "develop"
     schedule:
       interval: "weekly"
     cooldown:
@@ -20,7 +19,6 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "develop"
     schedule:
       interval: "weekly"
     cooldown:


### PR DESCRIPTION
`develop` has no commits since 2022-09 and is 22 commits behind `main` — dependabot PRs against it (#27, #28) were updating a dead branch. Point updates at the default branch instead.